### PR TITLE
Fixed bug with package-info file in factory packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.classpath
+.project
+.settings/

--- a/src/main/java/esa/mo/tools/stubgen/GeneratorJava.java
+++ b/src/main/java/esa/mo/tools/stubgen/GeneratorJava.java
@@ -429,7 +429,7 @@ public class GeneratorJava extends GeneratorLangs
   @Override
   protected void createStructureFactoryFolderComment(File structureFolder, AreaType area, ServiceType service) throws IOException
   {
-    createFolderComment(structureFolder, area, service, getConfig().getFactoryFolder(), "Factory classes for the types defined in the "
+    createFolderComment(structureFolder, area, service, getConfig().getStructureFolder()+"."+getConfig().getFactoryFolder(), "Factory classes for the types defined in the "
             + ((null == service) ? (area.getName() + " area.") : (service.getName() + " service.")));
   }
 


### PR DESCRIPTION
Fixed a bug where inside the generated structures.factory package, the package-info class has the wrong package name (misses the structures folder). 
